### PR TITLE
fix: handle errors in abstract controllers

### DIFF
--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -86,6 +86,20 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         #[ngyn::async_trait]
+        impl ngyn::NgynControllerRoutePlaceholder for #ident {
+            const routes: &'static [(&'static str, &'static str, &'static str)] = &[];
+
+            async fn __handle_route(
+                &self,
+                handler: String,
+                req: ngyn::NgynRequest,
+                res: &mut ngyn::NgynResponse,
+            ) {
+                // TODO: Handle routes
+            }
+        }
+
+        #[ngyn::async_trait]
         impl ngyn::NgynController for #ident {
             fn new(middlewares: Vec<std::sync::Arc<dyn ngyn::NgynMiddleware>>) -> Self {
                 #(#add_middlewares)*
@@ -97,12 +111,14 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             }
 
             fn get_routes(&self) -> Vec<(String, String, String)> {
-                Self::ROUTES.iter().map(|(path, method, handler)| {
+                use ngyn::NgynControllerRoutePlaceholder;
+                Self::routes.iter().map(|(path, method, handler)| {
                     (path.to_string(), method.to_string(), handler.to_string())
                 }).collect()
             }
 
             async fn handle(&self, handler: String, req: ngyn::NgynRequest, res: &mut ngyn::NgynResponse) {
+                use ngyn::NgynControllerRoutePlaceholder;
                 self.middlewares.iter().for_each(|middleware| {
                     middleware.handle(&req, res);
                 });

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -141,7 +141,7 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #defaultness #unsafety #(#attrs)*
         #impl_token #generics #self_ty {
-            const ROUTES: &'static [(&'static str, &'static str, &'static str)] = &[
+            const routes: &'static [(&'static str, &'static str, &'static str)] = &[
                 #(#route_defs),*
             ];
             #(#items)*

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -1,5 +1,5 @@
 #[async_trait::async_trait]
-/// `NgynController` is a trait that defines the basic structure of a controller in Ngyn.
+/// `NgynController` defines the basic structure of a controller in Ngyn.
 /// It is designed to be thread-safe.
 pub trait NgynController: Send + Sync {
     /// Creates a new instance of the controller.
@@ -11,7 +11,18 @@ pub trait NgynController: Send + Sync {
     /// Returns a vector of routes for the controller.
     fn get_routes(&self) -> Vec<(String, String, String)>;
 
-    /// Returns a `NgynResponse` for the controller.
-    /// This is for internal use only.
+    /// This is for internal use only. It handles the routing logic of the controller.
     async fn handle(&self, handler: String, req: crate::NgynRequest, res: &mut crate::NgynResponse);
+}
+
+#[async_trait::async_trait]
+/// `NgynControllerRoutePlaceholder` defines placeholders for routing logic of a controller.
+pub trait NgynControllerRoutePlaceholder {
+    const routes: &'static [(&'static str, &'static str, &'static str)];
+    async fn __handle_route(
+        &self,
+        handler: String,
+        req: crate::NgynRequest,
+        res: &mut crate::NgynResponse,
+    );
 }


### PR DESCRIPTION
We finally have improved support for controller routes. However, it comes with some costs.

- Abstract controllers became messy to create
- Multiple route impl became impossible.

This PR ensures we can create abstract controllers (controllers with no routes).
As for multiple route impl, it doesn't make much sense to have this feature, so I won't be bringing that back.