### PR TITLE
fix:  make requests partially mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ struct MyAppModule;
 async fn main() -> Result<()> {
     let app = NgynFactory::create::<MyAppModule>();
 
-    app.get("/", |req: &NgynRequest, res: &mut NgynResponse| {
+    app.get("/", |req: &mut NgynRequest, res: &mut NgynResponse| {
         res.send("Hello World!");
     });
 

--- a/crates/core/src/app/factory.rs
+++ b/crates/core/src/app/factory.rs
@@ -32,7 +32,7 @@ impl<Application: NgynEngine> NgynFactory<Application> {
                     http_method,
                     Box::new({
                         let controller = controller.clone();
-                        move |req: &NgynRequest, res: &mut NgynResponse| {
+                        move |req: &mut NgynRequest, res: &mut NgynResponse| {
                             res.with_controller(controller.clone(), handler.clone(), req);
                         }
                     }),

--- a/crates/core/src/platforms/tide.rs
+++ b/crates/core/src/platforms/tide.rs
@@ -63,9 +63,9 @@ impl NgynEngine for NgynApplication {
                 let handler = Arc::clone(&handler);
                 async move {
                     let values = request_to_values(req).await;
-                    let request = NgynRequest::from(values);
+                    let mut request = NgynRequest::from(values);
                     let mut response = NgynResponse::from_status(200);
-                    handler.handle(&request, &mut response);
+                    handler.handle(&mut request, &mut response);
                     Self::build(response.await)
                 }
             }

--- a/crates/core/src/platforms/vercel.rs
+++ b/crates/core/src/platforms/vercel.rs
@@ -37,13 +37,13 @@ impl VercelApplication {
                     }
                     entries
                 };
-                let req = NgynRequest::from((
+                let mut req = NgynRequest::from((
                     parts.method.to_string(),
                     uri.to_string(),
                     headers,
                     body.to_vec(),
                 ));
-                handler.handle(&req, &mut res);
+                handler.handle(&mut req, &mut res);
 
                 // Wait for the response to be ready
                 res = res.await;

--- a/crates/macros/src/common/check_macro.rs
+++ b/crates/macros/src/common/check_macro.rs
@@ -55,7 +55,7 @@ pub fn check_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             {
                 use ngyn::NgynGate;
                 let gate: #gate = ngyn::NgynProvider.provide();
-                if !gate.can_activate(&#req) {
+                if !gate.can_activate(#req) {
                     #res.set_status(403);
                     return ngyn::NgynBody::String("Forbidden".to_string());
                 }

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -87,12 +87,13 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
 
         #[ngyn::async_trait]
         impl ngyn::NgynControllerRoutePlaceholder for #ident {
+            #[allow(non_upper_case_globals)]
             const routes: &'static [(&'static str, &'static str, &'static str)] = &[];
 
             async fn __handle_route(
                 &self,
                 handler: String,
-                req: ngyn::NgynRequest,
+                req: &mut ngyn::NgynRequest,
                 res: &mut ngyn::NgynResponse,
             ) {
                 // TODO: Handle routes
@@ -117,10 +118,10 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
                 }).collect()
             }
 
-            async fn handle(&self, handler: String, req: ngyn::NgynRequest, res: &mut ngyn::NgynResponse) {
+            async fn handle(&self, handler: String, req: &mut ngyn::NgynRequest, res: &mut ngyn::NgynResponse) {
                 use ngyn::NgynControllerRoutePlaceholder;
                 self.middlewares.iter().for_each(|middleware| {
-                    middleware.handle(&req, res);
+                    middleware.handle(req, res);
                 });
                 self.__handle_route(handler, req, res).await;
             }

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -111,7 +111,7 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
                                 )});
                                 handle_routes.push(quote! {
                                     #ident_str => {
-                                        let body = self.#ident(&req, res).await;
+                                        let body = self.#ident(req, res).await;
                                         res.peek(body);
                                     }
                                 });
@@ -127,7 +127,7 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
                             )});
                             handle_routes.push(quote! {
                                 #ident_str => {
-                                    let body = self.#ident(&req, res).await;
+                                    let body = self.#ident(req, res).await;
                                     res.peek(body);
                                 }
                             });
@@ -141,12 +141,13 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #defaultness #unsafety #(#attrs)*
         #impl_token #generics #self_ty {
+            #[allow(non_upper_case_globals)]
             const routes: &'static [(&'static str, &'static str, &'static str)] = &[
                 #(#route_defs),*
             ];
             #(#items)*
 
-            async fn __handle_route(&self, handler: String, req: ngyn::NgynRequest, res: &mut ngyn::NgynResponse) {
+            async fn __handle_route(&self, handler: String, req: &mut ngyn::NgynRequest, res: &mut ngyn::NgynResponse) {
                 match handler.as_str() {
                     #(#handle_routes),*
                     _ => {

--- a/crates/shared/src/core/handler.rs
+++ b/crates/shared/src/core/handler.rs
@@ -1,14 +1,14 @@
 use crate::{NgynRequest, NgynResponse};
 
 pub trait Handler: Sync + Send + 'static {
-    fn handle(&self, req: &NgynRequest, res: &mut NgynResponse);
+    fn handle(&self, req: &mut NgynRequest, res: &mut NgynResponse);
 }
 
 impl<F> Handler for F
 where
-    F: Fn(&NgynRequest, &mut NgynResponse) + Send + Sync + 'static,
+    F: Fn(&mut NgynRequest, &mut NgynResponse) + Send + Sync + 'static,
 {
-    fn handle(&self, req: &NgynRequest, res: &mut NgynResponse) {
+    fn handle(&self, req: &mut NgynRequest, res: &mut NgynResponse) {
         self(req, res)
     }
 }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -114,7 +114,7 @@ impl NgynResponse {
         &mut self,
         controller: Arc<dyn NgynController>,
         handler: String,
-        request: &NgynRequest,
+        request: &mut NgynRequest,
     ) {
         self.route = Some(NgynResponseRoute {
             controller,
@@ -133,13 +133,13 @@ impl Future for NgynResponse {
         if let Some(NgynResponseRoute {
             controller,
             handler,
-            request,
+            mut request,
         }) = route.clone()
         {
             let mut response = self.clone();
 
             let _ = controller
-                .handle(handler, request, &mut response)
+                .handle(handler, &mut request, &mut response)
                 .as_mut()
                 .poll(cx);
 

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -12,17 +12,23 @@ pub trait NgynController: Send + Sync {
     fn get_routes(&self) -> Vec<(String, String, String)>;
 
     /// This is for internal use only. It handles the routing logic of the controller.
-    async fn handle(&self, handler: String, req: crate::NgynRequest, res: &mut crate::NgynResponse);
+    async fn handle(
+        &self,
+        handler: String,
+        req: &mut crate::NgynRequest,
+        res: &mut crate::NgynResponse,
+    );
 }
 
 #[async_trait::async_trait]
 /// `NgynControllerRoutePlaceholder` defines placeholders for routing logic of a controller.
 pub trait NgynControllerRoutePlaceholder {
+    #[allow(non_upper_case_globals)]
     const routes: &'static [(&'static str, &'static str, &'static str)];
     async fn __handle_route(
         &self,
         handler: String,
-        req: crate::NgynRequest,
+        req: &mut crate::NgynRequest,
         res: &mut crate::NgynResponse,
     );
 }

--- a/crates/shared/src/traits/gate_trait.rs
+++ b/crates/shared/src/traits/gate_trait.rs
@@ -11,5 +11,5 @@ pub trait NgynGate: NgynInjectable {
     /// ### Returns
     ///
     /// Returns `true` if the route can activate, `false` otherwise.
-    fn can_activate(self, request: &NgynRequest) -> bool;
+    fn can_activate(self, request: &mut NgynRequest) -> bool;
 }

--- a/crates/shared/src/traits/middleware_trait.rs
+++ b/crates/shared/src/traits/middleware_trait.rs
@@ -3,5 +3,5 @@ use crate::{NgynRequest, NgynResponse};
 /// Trait for implementing a middleware.
 pub trait NgynMiddleware: Send + Sync {
     /// Handles the request.
-    fn handle(&self, request: &NgynRequest, response: &mut NgynResponse);
+    fn handle(&self, request: &mut NgynRequest, response: &mut NgynResponse);
 }

--- a/examples/weather_app/src/middlewares/test_middleware.rs
+++ b/examples/weather_app/src/middlewares/test_middleware.rs
@@ -4,7 +4,7 @@ use ngyn::{injectable, NgynMiddleware, NgynRequest, NgynResponse};
 pub struct TestMiddleware;
 
 impl NgynMiddleware for TestMiddleware {
-    fn handle(&self, _request: &NgynRequest, _response: &mut NgynResponse) {
+    fn handle(&self, _request: &mut NgynRequest, _response: &mut NgynResponse) {
         println!("middleware works");
     }
 }

--- a/examples/weather_app/src/modules/home/home_controller.rs
+++ b/examples/weather_app/src/modules/home/home_controller.rs
@@ -6,7 +6,7 @@ pub struct HomeController;
 #[routes]
 impl HomeController {
     #[get("/")]
-    fn get_home(&self, _req: &NgynRequest, res: &mut NgynResponse) {
+    fn get_home(&self, _req: &mut NgynRequest, res: &mut NgynResponse) {
         res.send("Welcome to the weather app! Try /weather?location=London");
     }
 }

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -12,7 +12,7 @@ pub struct WeatherController {
 impl WeatherController {
     #[check(WeatherGate)]
     #[get("/weather")]
-    async fn get_location(&self, _req: &NgynRequest, res: &mut NgynResponse) -> NgynBody {
+    async fn get_location(&self, _req: &mut NgynRequest, res: &mut NgynResponse) -> NgynBody {
         let weather = self.weather_service.get_location_weather("London").await;
         weather.into()
     }

--- a/examples/weather_app/src/modules/weather/weather_gate.rs
+++ b/examples/weather_app/src/modules/weather/weather_gate.rs
@@ -4,7 +4,7 @@ use ngyn::{injectable, NgynGate};
 pub struct WeatherGate;
 
 impl NgynGate for WeatherGate {
-    fn can_activate(self, _request: &ngyn::NgynRequest) -> bool {
+    fn can_activate(self, _request: &mut ngyn::NgynRequest) -> bool {
         true
     }
 }


### PR DESCRIPTION
Requests in Ngyn started off as immutable entities. However, with the introduction of request contexts, they are now partially mutable.

Only contexts can be mutated. Every other component of a request is immutable by design and this is to encourage better practices