### PR TITLE
feat: add support for transducer transformers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -1183,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1458,6 +1458,9 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "nject",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -1582,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
@@ -2600,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2803,6 +2806,8 @@ dependencies = [
  "dotenv",
  "ngyn 0.3.0",
  "nject",
+ "serde",
+ "serde_json",
  "ureq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
-members = [
-  "crates/*",
-  "examples/*",
-]
+members = ["crates/*", "examples/*"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ nject = "0.3.0"
 And here's the code:
 
 ```rust
-use ngyn::prelude::*;
+use ngyn::{
+	platforms::{NgynApplication, Result},
+	prelude::*
+};
 
 #[controller]
 struct MyController;
@@ -56,7 +59,7 @@ struct MyAppModule;
 
 #[main]
 async fn main() -> Result<()> {
-    let app = NgynFactory::create::<MyAppModule>();
+    let app = NgynFactory::<NgynApplication>::create::<MyAppModule>();
 
     app.listen("127.0.0.1:8080").await?;
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ nject = "0.3.0"
 
 And here's the code:
 
-```rust
+```rust ignore
 use ngyn::{
 	platforms::{NgynApplication, Result},
 	prelude::*

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ impl MyController {
 #[module(controllers = [MyController])]
 struct MyAppModule;
 
-#[ngyn::main]
+#[main]
 async fn main() -> Result<()> {
     let app = NgynFactory::create::<MyAppModule>();
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ struct MyController;
 #[routes]
 impl MyController {
     #[get("/")]
-    async fn index(&self, _req: &mut NgynRequest, res: &mut NgynResponse) {
-        res.send("Hello World!");
+    fn index(&self) {
+        "Hello World!".to_string()
     }
 
     #[get("/hello/:name")]
-    async fn hello(&self, req: &mut NgynRequest, res: &mut NgynResponse) {
-        let name = req.param("name").unwrap();
-        res.send(format!("Hello, {}!", name));
+    fn hello(&self) {
+        let name = request.param("name").unwrap();
+        format!("Hello, {}!", name)
     }
 }
 

--- a/crates/core/src/app/factory.rs
+++ b/crates/core/src/app/factory.rs
@@ -14,7 +14,7 @@ impl<Application: NgynEngine> NgynFactory<Application> {
     /// ### Example
     ///
     /// ```
-    /// use ngyn::prelude::*;
+    /// use ngyn::{platforms::NgynApplication, prelude::*};
     ///
     /// #[module]
     /// pub struct YourAppModule;

--- a/crates/core/src/app/factory.rs
+++ b/crates/core/src/app/factory.rs
@@ -14,7 +14,7 @@ impl<Application: NgynEngine> NgynFactory<Application> {
     /// ### Example
     ///
     /// ```
-    /// use ngyn::{module, NgynFactory, platforms::NgynApplication};
+    /// use ngyn::prelude::*;
     ///
     /// #[module]
     /// pub struct YourAppModule;
@@ -25,7 +25,7 @@ impl<Application: NgynEngine> NgynFactory<Application> {
         let mut module = AppModule::new(vec![]);
         let mut server = Application::new();
         for controller in module.get_controllers() {
-            for (path, http_method, handler) in controller.get_routes() {
+            for (path, http_method, handler) in controller.routes() {
                 let http_method = HttpMethod::from(http_method);
                 server.route(
                     path.as_str(),

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -91,12 +91,11 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             const routes: &'static [(&'static str, &'static str, &'static str)] = &[];
 
             async fn __handle_route(
-                &self,
-                handler: String,
-                req: &mut ngyn::prelude::NgynRequest,
-                res: &mut ngyn::prelude::NgynResponse,
+                _handler: &str,
+                _req: &mut ngyn::prelude::NgynRequest,
+                _res: &mut ngyn::prelude::NgynResponse,
             ) {
-                // TODO: Handle routes
+                // This is a placeholder for the routing logic of the controller.
             }
         }
 
@@ -111,14 +110,14 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
                 controller
             }
 
-            fn get_routes(&self) -> Vec<(String, String, String)> {
+            fn routes(&self) -> Vec<(String, String, String)> {
                 use ngyn::prelude::NgynControllerRoutePlaceholder;
                 Self::routes.iter().map(|(path, method, handler)| {
                     (path.to_string(), method.to_string(), handler.to_string())
                 }).collect()
             }
 
-            async fn handle(&self, handler: String, req: &mut ngyn::prelude::NgynRequest, res: &mut ngyn::prelude::NgynResponse) {
+            async fn handle(&self, handler: &str, req: &mut ngyn::prelude::NgynRequest, res: &mut ngyn::prelude::NgynResponse) {
                 use ngyn::prelude::NgynControllerRoutePlaceholder;
                 self.middlewares.iter().for_each(|middleware| {
                     middleware.handle(req, res);

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -91,7 +91,7 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             const routes: &'static [(&'static str, &'static str, &'static str)] = &[];
 
             async fn __handle_route(
-            	&self,
+                &self,
                 _handler: &str,
                 _req: &mut ngyn::prelude::NgynRequest,
                 _res: &mut ngyn::prelude::NgynResponse,

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -91,6 +91,7 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             const routes: &'static [(&'static str, &'static str, &'static str)] = &[];
 
             async fn __handle_route(
+            	&self,
                 _handler: &str,
                 _req: &mut ngyn::prelude::NgynRequest,
                 _res: &mut ngyn::prelude::NgynResponse,

--- a/crates/macros/src/common/route_macro.rs
+++ b/crates/macros/src/common/route_macro.rs
@@ -45,22 +45,26 @@ pub fn route_macro(_args: TokenStream, raw_input: TokenStream) -> TokenStream {
 		.collect();
 
     // initial self varn obtained from the first input
-    let self_var = match inputs.iter().nth(0) {
-		Some(syn::FnArg::Receiver(receiver)) => {
-			let Receiver { reference, mutability, self_token, .. } = receiver;
-			if reference.is_some() {
-				if mutability.is_some() {
-					quote! { &mut #self_token }
-				} else {
-					quote! { &#self_token }
-				}
-			} else {
-				quote! { #self_token }
-			}
-
-		},
-		_ => quote! {},
-	};
+    let self_var = match inputs.iter().next() {
+        Some(syn::FnArg::Receiver(receiver)) => {
+            let Receiver {
+                reference,
+                mutability,
+                self_token,
+                ..
+            } = receiver;
+            if reference.is_some() {
+                if mutability.is_some() {
+                    quote! { &mut #self_token }
+                } else {
+                    quote! { &#self_token }
+                }
+            } else {
+                quote! { #self_token }
+            }
+        }
+        _ => quote! {},
+    };
 
     let return_val = match output {
         syn::ReturnType::Type(_, _) => quote! {},
@@ -75,7 +79,7 @@ pub fn route_macro(_args: TokenStream, raw_input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #(#attrs)*
         #vis async #fn_token #ident(#self_var, request: &mut ngyn::prelude::NgynRequest, response: &mut ngyn::prelude::NgynResponse) #output {
-        	#(#transducers)*
+            #(#transducers)*
             #block
             #return_val
         }

--- a/crates/macros/src/common/route_macro.rs
+++ b/crates/macros/src/common/route_macro.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{ItemFn, Signature};
+use syn::{ItemFn, Receiver, Signature};
 
 pub fn route_macro(_args: TokenStream, raw_input: TokenStream) -> TokenStream {
     let ItemFn {
@@ -24,19 +24,58 @@ pub fn route_macro(_args: TokenStream, raw_input: TokenStream) -> TokenStream {
         ..
     } = sig;
 
+    let transducers: Vec<_> = inputs
+		.iter()
+		.map(|input| {
+			if let syn::FnArg::Typed(pat) = input {
+				let ty = &pat.ty;
+				let pat = &pat.pat;
+				if let syn::Type::Path(path) = *ty.clone() {
+					let path = &path.path;
+					quote! {
+						let mut #pat: #path = ngyn::prelude::Transducer::reduce::<#path>(request, response);
+					}
+				} else {
+					panic!("Expected a valid struct");
+				}
+			} else {
+				quote! {}
+			}
+		})
+		.collect();
+
+    // initial self varn obtained from the first input
+    let self_var = match inputs.iter().nth(0) {
+		Some(syn::FnArg::Receiver(receiver)) => {
+			let Receiver { reference, mutability, self_token, .. } = receiver;
+			if reference.is_some() {
+				if mutability.is_some() {
+					quote! { &mut #self_token }
+				} else {
+					quote! { &#self_token }
+				}
+			} else {
+				quote! { #self_token }
+			}
+
+		},
+		_ => quote! {},
+	};
+
     let return_val = match output {
         syn::ReturnType::Type(_, _) => quote! {},
         _ => quote! { return ngyn::prelude::NgynBody::None; },
     };
 
     let output = match output {
-        syn::ReturnType::Type(_, ty) => quote! { -> #ty }, // TODO: Handle other types aside NgynBody
+        syn::ReturnType::Type(_, ty) => quote! { -> #ty },
         _ => quote! { -> ngyn::prelude::NgynBody },
     };
 
     let expanded = quote! {
         #(#attrs)*
-        #vis async #fn_token #ident(#inputs) #output {
+        #vis async #fn_token #ident(#self_var, request: &mut ngyn::prelude::NgynRequest, response: &mut ngyn::prelude::NgynResponse) #output {
+        	#(#transducers)*
             #block
             #return_val
         }

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -129,10 +129,10 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
             #(#items)*
 
             async fn __handle_route(
-            	&self,
-             	handler: &str,
-              	req: &mut ngyn::prelude::NgynRequest,
-               	res: &mut ngyn::prelude::NgynResponse
+                &self,
+                 handler: &str,
+                  req: &mut ngyn::prelude::NgynRequest,
+                   res: &mut ngyn::prelude::NgynResponse
             ) {
                 match handler {
                     #(#handle_routes),*

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -128,8 +128,8 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
             ];
             #(#items)*
 
-            async fn __handle_route(&self, handler: String, req: &mut ngyn::prelude::NgynRequest, res: &mut ngyn::prelude::NgynResponse) {
-                match handler.as_str() {
+            async fn __handle_route(handler: &str, req: &mut ngyn::prelude::NgynRequest, res: &mut ngyn::prelude::NgynResponse) {
+                match handler {
                     #(#handle_routes),*
                     _ => {
                         res.set_status(404);

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -128,7 +128,12 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
             ];
             #(#items)*
 
-            async fn __handle_route(handler: &str, req: &mut ngyn::prelude::NgynRequest, res: &mut ngyn::prelude::NgynResponse) {
+            async fn __handle_route(
+            	&self,
+             	handler: &str,
+              	req: &mut ngyn::prelude::NgynRequest,
+               	res: &mut ngyn::prelude::NgynResponse
+            ) {
                 match handler {
                     #(#handle_routes),*
                     _ => {

--- a/crates/macros/src/common/routes_macro.rs
+++ b/crates/macros/src/common/routes_macro.rs
@@ -130,9 +130,9 @@ pub fn routes_macro(raw_input: TokenStream) -> TokenStream {
 
             async fn __handle_route(
                 &self,
-                 handler: &str,
-                  req: &mut ngyn::prelude::NgynRequest,
-                   res: &mut ngyn::prelude::NgynResponse
+                handler: &str,
+                req: &mut ngyn::prelude::NgynRequest,
+                res: &mut ngyn::prelude::NgynResponse
             ) {
                 match handler {
                     #(#handle_routes),*

--- a/crates/macros/src/core/dto_macro.rs
+++ b/crates/macros/src/core/dto_macro.rs
@@ -1,0 +1,18 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+
+pub fn dto_macro(input: TokenStream) -> TokenStream {
+	let input = syn::parse_macro_input!(input as syn::DeriveInput);
+	let ident = &input.ident;
+
+	let expanded = quote! {
+		impl ngyn::prelude::Transformer for #ident {
+			fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
+				let dto = ngyn::prelude::Dto::transform(req, res);
+				dto.parse::<#ident>().unwrap()
+			}
+		}
+	};
+	expanded.into()
+}

--- a/crates/macros/src/core/dto_macro.rs
+++ b/crates/macros/src/core/dto_macro.rs
@@ -1,18 +1,17 @@
 use proc_macro::TokenStream;
 use quote::quote;
 
-
 pub fn dto_macro(input: TokenStream) -> TokenStream {
-	let input = syn::parse_macro_input!(input as syn::DeriveInput);
-	let ident = &input.ident;
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+    let ident = &input.ident;
 
-	let expanded = quote! {
-		impl ngyn::prelude::Transformer for #ident {
-			fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
-				let dto = ngyn::prelude::Dto::transform(req, res);
-				dto.parse::<#ident>().unwrap()
-			}
-		}
-	};
-	expanded.into()
+    let expanded = quote! {
+        impl ngyn::prelude::Transformer for #ident {
+            fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
+                let dto = ngyn::prelude::Dto::transform(req, res);
+                dto.parse::<#ident>().unwrap()
+            }
+        }
+    };
+    expanded.into()
 }

--- a/crates/macros/src/core/mod.rs
+++ b/crates/macros/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod module_macro;
 pub mod platform_macro;
+pub mod dto_macro;

--- a/crates/macros/src/core/mod.rs
+++ b/crates/macros/src/core/mod.rs
@@ -1,3 +1,3 @@
+pub mod dto_macro;
 pub mod module_macro;
 pub mod platform_macro;
-pub mod dto_macro;

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -8,6 +8,7 @@ use crate::common::check_macro::check_fn_macro;
 use crate::common::{controller_macro::*, injectable_macro::*, route_macro::*, routes_macro::*};
 use crate::core::module_macro::*;
 use crate::core::platform_macro::platform_macro;
+use crate::core::dto_macro::dto_macro;
 
 use common::check_macro::check_impl_macro;
 use proc_macro::TokenStream;
@@ -110,4 +111,11 @@ pub fn check(args: TokenStream, input: TokenStream) -> TokenStream {
         Ok(syn::Item::Impl(impl_item)) => check_impl_macro(impl_item, args),
         _ => panic!("`check` attribute can only be used on methods or impl blocks"),
     }
+}
+
+
+#[proc_macro_derive(Dto)]
+/// The `Dto` derive macro is used to generate a DTO struct.
+pub fn dto(input: TokenStream) -> TokenStream {
+	dto_macro(input)
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -6,9 +6,9 @@ mod utils;
 
 use crate::common::check_macro::check_fn_macro;
 use crate::common::{controller_macro::*, injectable_macro::*, route_macro::*, routes_macro::*};
+use crate::core::dto_macro::dto_macro;
 use crate::core::module_macro::*;
 use crate::core::platform_macro::platform_macro;
-use crate::core::dto_macro::dto_macro;
 
 use common::check_macro::check_impl_macro;
 use proc_macro::TokenStream;
@@ -113,9 +113,8 @@ pub fn check(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-
 #[proc_macro_derive(Dto)]
 /// The `Dto` derive macro is used to generate a DTO struct.
 pub fn dto(input: TokenStream) -> TokenStream {
-	dto_macro(input)
+    dto_macro(input)
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -10,3 +10,6 @@ license = "MIT"
 [dependencies]
 async-trait = "0.1.74"
 nject = "0.3.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+url = "2.5.0"

--- a/crates/shared/src/server/mod.rs
+++ b/crates/shared/src/server/mod.rs
@@ -7,4 +7,4 @@ pub mod transformer;
 pub use body::{IntoNgynBody, NgynBody};
 pub use request::NgynRequest;
 pub use response::NgynResponse;
-pub use transformer::{Transducer, Transformer, Query, Dto, Param};
+pub use transformer::{Dto, Param, Query, Transducer, Transformer};

--- a/crates/shared/src/server/mod.rs
+++ b/crates/shared/src/server/mod.rs
@@ -2,7 +2,9 @@ pub mod body;
 pub mod context;
 pub mod request;
 pub mod response;
+pub mod transformer;
 
 pub use body::{IntoNgynBody, NgynBody};
 pub use request::NgynRequest;
 pub use response::NgynResponse;
+pub use transformer::{Transducer, Transformer, Query, Dto, Param};

--- a/crates/shared/src/server/request.rs
+++ b/crates/shared/src/server/request.rs
@@ -52,34 +52,39 @@ impl NgynRequest {
     }
 
     pub fn params(&self) -> &HashMap<String, String> {
-		&self.params
-	}
+        &self.params
+    }
 
-	pub fn set_params(&mut self, params: HashMap<String, String>) {
-		if !self.params.is_empty() {
-			panic!("Params have already been set");
-		}
-		self.params = params;
-	}
+    pub fn set_params(&mut self, params: HashMap<String, String>) {
+        if !self.params.is_empty() {
+            panic!("Params have already been set");
+        }
+        self.params = params;
+    }
 
-	pub fn from_method(method: HttpMethod, url: &str, body: Option<Vec<u8>>, headers: HashMap<String, String>) -> Self {
-		Self {
-			method,
-			url: Url::parse(url).unwrap(),
-			headers,
-			body,
-			context: NgynContext::default(),
-			params: HashMap::new(),
-		}
-	}
+    pub fn from_method(
+        method: HttpMethod,
+        url: &str,
+        body: Option<Vec<u8>>,
+        headers: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            method,
+            url: Url::parse(url).unwrap(),
+            headers,
+            body,
+            context: NgynContext::default(),
+            params: HashMap::new(),
+        }
+    }
 
     pub fn from_get(url: &str, headers: HashMap<String, String>) -> Self {
-		Self::from_method(HttpMethod::Get, url, None, headers)
-	}
+        Self::from_method(HttpMethod::Get, url, None, headers)
+    }
 
-	pub fn from_post(url: &str, body: Vec<u8>, headers: HashMap<String, String>) -> Self {
-		Self::from_method(HttpMethod::Post, url, Some(body), headers)
-	}
+    pub fn from_post(url: &str, body: Vec<u8>, headers: HashMap<String, String>) -> Self {
+        Self::from_method(HttpMethod::Post, url, Some(body), headers)
+    }
 }
 
 impl From<(String, String, HashMap<String, String>, Vec<u8>)> for NgynRequest {
@@ -90,7 +95,7 @@ impl From<(String, String, HashMap<String, String>, Vec<u8>)> for NgynRequest {
 }
 
 impl Transformer for NgynRequest {
-	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Self {
-		req.clone()
-	}
+    fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Self {
+        req.clone()
+    }
 }

--- a/crates/shared/src/server/request.rs
+++ b/crates/shared/src/server/request.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
+use url::Url;
+
 use super::context::NgynContext;
-use crate::enums::HttpMethod;
+use crate::{enums::HttpMethod, transformer::Transformer, NgynResponse};
 
 /// A struct that represents a request.
 #[derive(Clone)]
@@ -9,13 +11,15 @@ pub struct NgynRequest {
     /// The HTTP method of the request.
     method: HttpMethod,
     /// The URL of the request.
-    url: String,
+    url: Url,
     /// The headers of the request.
     headers: HashMap<String, String>,
-    /// bytes format
+    /// body of the request in bytes format
     body: Option<Vec<u8>>,
     /// context for the request
     pub context: NgynContext,
+    /// The parameters of the request.
+    params: HashMap<String, String>,
 }
 
 impl NgynRequest {
@@ -24,7 +28,7 @@ impl NgynRequest {
             return Ok(body.clone());
         }
         self.body = None;
-        panic!("Body has already been read");
+        panic!("Body has already been read. Do you have more than one Dto in your route?");
     }
 
     /// Gets the body of the `NgynRequest`.
@@ -38,25 +42,55 @@ impl NgynRequest {
     }
 
     /// Gets the URL of the `NgynRequest`.
-    pub fn url(&self) -> &str {
-        self.url.as_str()
+    pub fn url(&self) -> &Url {
+        &self.url
     }
 
     /// Gets the headers of the `NgynRequest`.
     pub fn headers(&self) -> &HashMap<String, String> {
         &self.headers
     }
+
+    pub fn params(&self) -> &HashMap<String, String> {
+		&self.params
+	}
+
+	pub fn set_params(&mut self, params: HashMap<String, String>) {
+		if !self.params.is_empty() {
+			panic!("Params have already been set");
+		}
+		self.params = params;
+	}
+
+	pub fn from_method(method: HttpMethod, url: &str, body: Option<Vec<u8>>, headers: HashMap<String, String>) -> Self {
+		Self {
+			method,
+			url: Url::parse(url).unwrap(),
+			headers,
+			body,
+			context: NgynContext::default(),
+			params: HashMap::new(),
+		}
+	}
+
+    pub fn from_get(url: &str, headers: HashMap<String, String>) -> Self {
+		Self::from_method(HttpMethod::Get, url, None, headers)
+	}
+
+	pub fn from_post(url: &str, body: Vec<u8>, headers: HashMap<String, String>) -> Self {
+		Self::from_method(HttpMethod::Post, url, Some(body), headers)
+	}
 }
 
 impl From<(String, String, HashMap<String, String>, Vec<u8>)> for NgynRequest {
     fn from(value: (String, String, HashMap<String, String>, Vec<u8>)) -> Self {
         let (method, url, headers, body) = value;
-        Self {
-            method: method.into(),
-            url,
-            headers,
-            body: Some(body),
-            context: NgynContext::default(),
-        }
+        Self::from_method(method.into(), &url, Some(body), headers)
     }
+}
+
+impl Transformer for NgynRequest {
+	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Self {
+		req.clone()
+	}
 }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -5,7 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::{body::IntoNgynBody, NgynBody, NgynController, NgynRequest};
+use crate::{body::IntoNgynBody, transformer::Transformer, NgynBody, NgynController, NgynRequest};
 
 #[derive(Clone)]
 pub struct NgynResponseRoute {
@@ -148,4 +148,10 @@ impl Future for NgynResponse {
             Poll::Ready(self.clone())
         }
     }
+}
+
+impl Transformer for NgynResponse {
+	fn transform(_req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
+		res.clone()
+	}
 }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -151,7 +151,7 @@ impl Future for NgynResponse {
 }
 
 impl Transformer for NgynResponse {
-	fn transform(_req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
-		res.clone()
-	}
+    fn transform(_req: &mut NgynRequest, res: &mut NgynResponse) -> Self {
+        res.clone()
+    }
 }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -139,7 +139,7 @@ impl Future for NgynResponse {
             let mut response = self.clone();
 
             let _ = controller
-                .handle(handler, &mut request, &mut response)
+                .handle(&handler, &mut request, &mut response)
                 .as_mut()
                 .poll(cx);
 

--- a/crates/shared/src/server/transformer.rs
+++ b/crates/shared/src/server/transformer.rs
@@ -4,58 +4,65 @@ use url::Url;
 use crate::{NgynRequest, NgynResponse};
 
 pub trait Transformer {
-	fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self;
+    fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self;
 }
 
 pub struct Transducer;
 
 impl Transducer {
-	#[allow(dead_code)]
-	pub fn reduce<S: Transformer>(req: &mut NgynRequest, res: &mut NgynResponse) -> S {
-		S::transform(req, res)
-	}
+    #[allow(dead_code)]
+    pub fn reduce<S: Transformer>(req: &mut NgynRequest, res: &mut NgynResponse) -> S {
+        S::transform(req, res)
+    }
 }
 
 pub struct Param {
-	data: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+    data: Vec<(Cow<'static, str>, Cow<'static, str>)>,
 }
 
 impl Param {
-	#[allow(dead_code)]
-	pub fn get(&self, id: &str) -> Option<String> {
-		for (key, value) in &self.data {
-			if key == id {
-				return Some(value.to_string());
-			}
-		}
-		None
-	}
+    #[allow(dead_code)]
+    pub fn get(&self, id: &str) -> Option<String> {
+        for (key, value) in &self.data {
+            if key == id {
+                return Some(value.to_string());
+            }
+        }
+        None
+    }
 }
 
 impl Transformer for Param {
-	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Param {
-		let data: Vec<(Cow<'static, str>, Cow<'static, str>)> = req.params().into_iter()
-			.map(|(key, value)| (Cow::Owned(key.to_string()), Cow::Owned(value.to_string())))
-			.collect();
-		Param { data }
-	}
+    fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Param {
+        let data: Vec<(Cow<'static, str>, Cow<'static, str>)> = req
+            .params()
+            .iter()
+            .map(|(key, value)| (Cow::Owned(key.to_string()), Cow::Owned(value.to_string())))
+            .collect();
+        Param { data }
+    }
 }
 
-
 pub struct Query {
-   url: Url,
+    url: Url,
 }
 
 impl Query {
     #[allow(dead_code)]
     pub fn get(&self, id: &str) -> Option<String> {
-        self.url.query_pairs().filter(|(key, _)| key == id).map(|(_, value)| value.to_string()).next()
+        self.url
+            .query_pairs()
+            .filter(|(key, _)| key == id)
+            .map(|(_, value)| value.to_string())
+            .next()
     }
 }
 
 impl Transformer for Query {
-	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Query {
-		Query { url: req.url().clone() }
+    fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Query {
+        Query {
+            url: req.url().clone(),
+        }
     }
 }
 
@@ -71,10 +78,9 @@ impl Dto {
     }
 }
 
-
 impl Transformer for Dto {
-	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Dto {
-		let data = req.body_string().unwrap_or("{}".to_string());
-		Dto { data }
-	}
+    fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Dto {
+        let data = req.body_string().unwrap_or("{}".to_string());
+        Dto { data }
+    }
 }

--- a/crates/shared/src/server/transformer.rs
+++ b/crates/shared/src/server/transformer.rs
@@ -1,0 +1,80 @@
+use std::borrow::Cow;
+use url::Url;
+
+use crate::{NgynRequest, NgynResponse};
+
+pub trait Transformer {
+	fn transform(req: &mut NgynRequest, res: &mut NgynResponse) -> Self;
+}
+
+pub struct Transducer;
+
+impl Transducer {
+	#[allow(dead_code)]
+	pub fn reduce<S: Transformer>(req: &mut NgynRequest, res: &mut NgynResponse) -> S {
+		S::transform(req, res)
+	}
+}
+
+pub struct Param {
+	data: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+}
+
+impl Param {
+	#[allow(dead_code)]
+	pub fn get(&self, id: &str) -> Option<String> {
+		for (key, value) in &self.data {
+			if key == id {
+				return Some(value.to_string());
+			}
+		}
+		None
+	}
+}
+
+impl Transformer for Param {
+	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Param {
+		let data: Vec<(Cow<'static, str>, Cow<'static, str>)> = req.params().into_iter()
+			.map(|(key, value)| (Cow::Owned(key.to_string()), Cow::Owned(value.to_string())))
+			.collect();
+		Param { data }
+	}
+}
+
+
+pub struct Query {
+   url: Url,
+}
+
+impl Query {
+    #[allow(dead_code)]
+    pub fn get(&self, id: &str) -> Option<String> {
+        self.url.query_pairs().filter(|(key, _)| key == id).map(|(_, value)| value.to_string()).next()
+    }
+}
+
+impl Transformer for Query {
+	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Query {
+		Query { url: req.url().clone() }
+    }
+}
+
+pub struct Dto {
+    data: String,
+}
+
+impl Dto {
+    #[allow(dead_code)]
+    pub fn parse<S: for<'a> serde::Deserialize<'a>>(&self) -> Result<S, serde_json::Error> {
+        let data = self.data.as_str();
+        serde_json::from_str(data)
+    }
+}
+
+
+impl Transformer for Dto {
+	fn transform(req: &mut NgynRequest, _res: &mut NgynResponse) -> Dto {
+		let data = req.body_string().unwrap_or("{}".to_string());
+		Dto { data }
+	}
+}

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -26,6 +26,7 @@ pub trait NgynControllerRoutePlaceholder {
     #[allow(non_upper_case_globals)]
     const routes: &'static [(&'static str, &'static str, &'static str)];
     async fn __handle_route(
+    	&self,
         handler: &str,
         req: &mut crate::NgynRequest,
         res: &mut crate::NgynResponse,

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -26,7 +26,7 @@ pub trait NgynControllerRoutePlaceholder {
     #[allow(non_upper_case_globals)]
     const routes: &'static [(&'static str, &'static str, &'static str)];
     async fn __handle_route(
-    	&self,
+        &self,
         handler: &str,
         req: &mut crate::NgynRequest,
         res: &mut crate::NgynResponse,

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -9,12 +9,12 @@ pub trait NgynController: Send + Sync {
         Self: Sized;
 
     /// Returns a vector of routes for the controller.
-    fn get_routes(&self) -> Vec<(String, String, String)>;
+    fn routes(&self) -> Vec<(String, String, String)>;
 
     /// This is for internal use only. It handles the routing logic of the controller.
     async fn handle(
         &self,
-        handler: String,
+        handler: &str,
         req: &mut crate::NgynRequest,
         res: &mut crate::NgynResponse,
     );
@@ -26,8 +26,7 @@ pub trait NgynControllerRoutePlaceholder {
     #[allow(non_upper_case_globals)]
     const routes: &'static [(&'static str, &'static str, &'static str)];
     async fn __handle_route(
-        &self,
-        handler: String,
+        handler: &str,
         req: &mut crate::NgynRequest,
         res: &mut crate::NgynResponse,
     );

--- a/examples/weather_app/Cargo.toml
+++ b/examples/weather_app/Cargo.toml
@@ -10,4 +10,6 @@ async-std = { version = "1", features = ["attributes", "tokio1"] }
 dotenv = "0.15.0"
 nject = "0.3.0"
 ngyn = { version = "0.3.0", path = "../../crates/core", features = ["tide"] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
 ureq = { version = "2.8.0" }

--- a/examples/weather_app/src/modules/home/home_controller.rs
+++ b/examples/weather_app/src/modules/home/home_controller.rs
@@ -6,7 +6,8 @@ pub struct HomeController;
 #[routes]
 impl HomeController {
     #[get("/")]
-    fn get_home(&self, _req: &mut NgynRequest, res: &mut NgynResponse) {
-        res.send("Welcome to the weather app! Try /weather?location=London");
+    fn get_home(&self, query: Query) -> String {
+    	println!("{:?}", query.get("location"));
+        "Welcome to the weather app! Try /weather?location=London".to_string()
     }
 }

--- a/examples/weather_app/src/modules/home/home_controller.rs
+++ b/examples/weather_app/src/modules/home/home_controller.rs
@@ -7,7 +7,7 @@ pub struct HomeController;
 impl HomeController {
     #[get("/")]
     fn get_home(&self, query: Query) -> String {
-    	println!("{:?}", query.get("location"));
+        println!("{:?}", query.get("location"));
         "Welcome to the weather app! Try /weather?location=London".to_string()
     }
 }

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -28,6 +28,6 @@ impl WeatherController {
     #[check(WeatherGate)]
     async fn post_location(&self, weather: WeatherDto) -> String {
         let location = weather.location;
-		self.weather_service.get_location_weather("London").await
+		self.weather_service.get_location_weather(&location).await
 	}
 }

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -1,14 +1,14 @@
 use ngyn::prelude::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::weather_gate::WeatherGate;
 use super::weather_service::WeatherService;
 
 #[derive(Dto, Serialize, Deserialize)]
 pub struct WeatherDto {
-	pub location: String,
-	pub temperature: f32,
-	pub humidity: f32,
+    pub location: String,
+    pub temperature: f32,
+    pub humidity: f32,
 }
 
 #[controller(middlewares = [])]
@@ -28,6 +28,6 @@ impl WeatherController {
     #[check(WeatherGate)]
     async fn post_location(&self, weather: WeatherDto) -> String {
         let location = weather.location;
-		self.weather_service.get_location_weather(&location).await
-	}
+        self.weather_service.get_location_weather(&location).await
+    }
 }

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -1,7 +1,15 @@
 use ngyn::prelude::*;
+use serde::{Serialize, Deserialize};
 
 use super::weather_gate::WeatherGate;
 use super::weather_service::WeatherService;
+
+#[derive(Dto, Serialize, Deserialize)]
+pub struct WeatherDto {
+	pub location: String,
+	pub temperature: f32,
+	pub humidity: f32,
+}
 
 #[controller(middlewares = [])]
 pub struct WeatherController {
@@ -10,9 +18,16 @@ pub struct WeatherController {
 
 #[routes]
 impl WeatherController {
-    #[check(WeatherGate)]
     #[get("/weather")]
-    async fn get_location(&self, _req: &mut NgynRequest, res: &mut NgynResponse) -> String {
+    #[check(WeatherGate)]
+    async fn get_location(&self) -> String {
         self.weather_service.get_location_weather("London").await
     }
+
+    #[post("/weather")]
+    #[check(WeatherGate)]
+    async fn post_location(&self, weather: WeatherDto) -> String {
+        let location = weather.location;
+		self.weather_service.get_location_weather("London").await
+	}
 }


### PR DESCRIPTION
This PR adds support for transducers, a new feature addition to engine.
Transducing is how Ngyn is able to deduce a requested data based on a struct whhich implenments the Transformer Trait.

This PR is a first in a series of changes and improvements coming to Ngyn and inspired by exsiting frameworks such as Axum.
