### PR TITLE
feat: add support for route path prefixes in controllers

### DIFF
--- a/crates/core/src/platforms/hyper.rs
+++ b/crates/core/src/platforms/hyper.rs
@@ -49,16 +49,18 @@ impl HyperApplication {
             let middlewares = Arc::clone(&middlewares);
             async move {
                 let (parts, mut body) = req.into_parts();
-                let req = Request::from_parts(
-                    parts,
-                    body.frame()
-                        .await
-                        .unwrap()
-                        .unwrap()
-                        .into_data()
-                        .unwrap()
-                        .to_vec(),
-                );
+                let body = {
+                    let mut buf = Vec::new();
+                    if let Some(frame) = body.frame().await {
+                        let chunk = frame?.into_data();
+                        match chunk {
+                            Ok(data) => buf.extend_from_slice(&data),
+                            Err(_) => {}
+                        }
+                    }
+                    buf
+                };
+                let req = Request::from_parts(parts, body);
                 let res = NgynResponse::init(req, routes, middlewares).await;
 
                 Ok::<_, hyper::Error>(res)

--- a/crates/core/src/platforms/hyper.rs
+++ b/crates/core/src/platforms/hyper.rs
@@ -53,9 +53,8 @@ impl HyperApplication {
                     let mut buf = Vec::new();
                     if let Some(frame) = body.frame().await {
                         let chunk = frame?.into_data();
-                        match chunk {
-                            Ok(data) => buf.extend_from_slice(&data),
-                            Err(_) => {}
+                        if let Ok(data) = chunk {
+                            buf.extend_from_slice(&data)
                         }
                     }
                     buf

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -4,20 +4,26 @@ use quote::quote;
 use crate::utils::parse_macro_data;
 
 struct ControllerArgs {
+    prefix: Option<syn::LitStr>,
     middlewares: Vec<syn::Path>,
 }
 
 impl syn::parse::Parse for ControllerArgs {
-    /// Parses a string like `routes = "get_location, get_location_weather", middlewares = [WeatherGate]`
+    /// Parses a string like `prefix="/weather", middlewares = [WeatherGate]`
     /// into a `ControllerArgs` struct.
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut middlewares = vec![];
+        let mut prefix = None;
 
         while !input.is_empty() {
             let ident: syn::Ident = input.parse()?;
             input.parse::<syn::Token![=]>()?;
 
             match ident.to_string().as_str() {
+                "prefix" => {
+                    let path: syn::LitStr = input.parse()?;
+                    prefix = Some(path);
+                }
                 "middlewares" => {
                     let content;
                     syn::bracketed!(content in input);
@@ -41,7 +47,10 @@ impl syn::parse::Parse for ControllerArgs {
             }
         }
 
-        Ok(ControllerArgs { middlewares })
+        Ok(ControllerArgs {
+            middlewares,
+            prefix,
+        })
     }
 }
 
@@ -53,7 +62,10 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
         vis,
         generics,
     } = syn::parse_macro_input!(input as syn::DeriveInput);
-    let args = syn::parse_macro_input!(args as ControllerArgs);
+    let ControllerArgs {
+        middlewares,
+        prefix,
+    } = syn::parse_macro_input!(args as ControllerArgs);
     let (types, keys) = parse_macro_data(data);
 
     let fields: Vec<_> = types
@@ -66,8 +78,7 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let add_middlewares: Vec<_> = args
-        .middlewares
+    let add_middlewares: Vec<_> = middlewares
         .iter()
         .map(|m| {
             quote! {
@@ -77,11 +88,23 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
         })
         .collect();
 
+    let path_prefix = {
+        if let Some(prefix) = prefix {
+            quote! {
+                #prefix.to_string() + "/"
+            }
+        } else {
+            quote! {
+                "".to_string()
+            }
+        }
+    };
+
     let expanded = quote! {
         #(#attrs)*
         #[ngyn::macros::dependency]
         #vis struct #ident #generics {
-            middlewares: Vec<std::sync::Arc<dyn ngyn::prelude::NgynMiddleware>>,
+            data: ngyn::prelude::NgynControllerData,
             #(#fields),*
         }
 
@@ -105,7 +128,7 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             fn new(middlewares: Vec<std::sync::Arc<dyn ngyn::prelude::NgynMiddleware>>) -> Self {
                 #(#add_middlewares)*
                 let mut controller = #ident {
-                    middlewares,
+                    data: ngyn::prelude::NgynControllerData::new(middlewares),
                     #(#keys: ngyn::prelude::NgynProvider.provide()),*
                 };
                 controller
@@ -114,13 +137,13 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             fn routes(&self) -> Vec<(String, String, String)> {
                 use ngyn::prelude::NgynControllerRoutePlaceholder;
                 Self::routes.iter().map(|(path, method, handler)| {
-                    (path.to_string(), method.to_string(), handler.to_string())
+                    (#path_prefix + path, method.to_string(), handler.to_string())
                 }).collect()
             }
 
             async fn handle(&self, handler: &str, cx: &mut ngyn::prelude::NgynContext, res: &mut ngyn::prelude::NgynResponse) {
                 use ngyn::prelude::NgynControllerRoutePlaceholder;
-                self.middlewares.iter().for_each(|middleware| {
+                self.data.middlewares().iter().for_each(|middleware| {
                     middleware.handle(cx, res);
                 });
                 self.__handle_route(handler, cx, res).await;

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -15,6 +15,17 @@ impl syn::parse::Parse for ControllerArgs {
         let mut middlewares = vec![];
         let mut prefix = None;
 
+        // match the input with format "/prefix"
+        if !input.is_empty() && input.peek(syn::LitStr) {
+            let path: syn::LitStr = input.parse()?;
+            prefix = Some(path);
+
+            return Ok(ControllerArgs {
+                middlewares,
+                prefix,
+            });
+        }
+
         while !input.is_empty() {
             let ident: syn::Ident = input.parse()?;
             input.parse::<syn::Token![=]>()?;

--- a/crates/macros/src/common/controller_macro.rs
+++ b/crates/macros/src/common/controller_macro.rs
@@ -148,7 +148,7 @@ pub fn controller_macro(args: TokenStream, input: TokenStream) -> TokenStream {
             fn routes(&self) -> Vec<(String, String, String)> {
                 use ngyn::prelude::NgynControllerRoutePlaceholder;
                 Self::routes.iter().map(|(path, method, handler)| {
-                    (#path_prefix + path, method.to_string(), handler.to_string())
+                    ((#path_prefix + path).replace("//", "/"), method.to_string(), handler.to_string())
                 }).collect()
             }
 

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -104,10 +104,6 @@ impl ResponseBuilder for NgynResponse {
         let mut cx = NgynContext::from_request(req);
         let mut res = Response::new(Full::new(Bytes::default()));
 
-        middlewares
-            .iter()
-            .for_each(|middleware| middleware.handle(&mut cx, &mut res));
-
         let handler = routes
             .iter()
             .filter_map(|(path, method, handler)| {
@@ -118,6 +114,10 @@ impl ResponseBuilder for NgynResponse {
                 }
             })
             .next();
+
+        middlewares
+            .iter()
+            .for_each(|middleware| middleware.handle(&mut cx, &mut res));
 
         if let Some(handler) = handler {
             handler(&mut cx, &mut res);

--- a/crates/shared/src/traits/controller_trait.rs
+++ b/crates/shared/src/traits/controller_trait.rs
@@ -32,3 +32,18 @@ pub trait NgynControllerRoutePlaceholder {
         res: &mut crate::NgynResponse,
     );
 }
+
+pub struct NgynControllerData {
+    middlewares: Vec<std::sync::Arc<dyn super::NgynMiddleware>>,
+}
+
+impl NgynControllerData {
+    /// Creates a new instance of `NgynControllerData`.
+    pub fn new(middlewares: Vec<std::sync::Arc<dyn super::NgynMiddleware>>) -> Self {
+        Self { middlewares }
+    }
+
+    pub fn middlewares(&self) -> &Vec<std::sync::Arc<dyn super::NgynMiddleware>> {
+        &self.middlewares
+    }
+}

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -12,14 +12,14 @@ pub struct WeatherDto {
     pub humidity: f32,
 }
 
-#[controller(middlewares = [])]
+#[controller("/weather")]
 pub struct WeatherController {
     weather_service: WeatherService,
 }
 
 #[routes]
 impl WeatherController {
-    #[get("/weather/<location>/<city>")]
+    #[get("/<location>/<city>")]
     #[check(WeatherGate)]
     async fn get_location(&self, params: Param) -> String {
         self.weather_service
@@ -27,7 +27,7 @@ impl WeatherController {
             .await
     }
 
-    #[post("/weather")]
+    #[post("/")]
     async fn post_location(&self, weather: WeatherDto) -> String {
         let location = weather.location;
         self.weather_service.get_location_weather(&location).await


### PR DESCRIPTION
```rust
[#controlller("/api")]
struct MyAPIController
```

```rust
[#controlller(prefix = "/api")]
struct MyAPIController
```

Closes #85 