### PR TITLE
fix: restructure dto and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ struct MyController;
 #[routes]
 impl MyController {
     #[get("/")]
-    fn index(&self) {
+    fn index(&self) -> String {
         "Hello World!".to_string()
     }
 
     #[get("/hello/<name>")]
-    fn hello(&self, param: Param) {
+    fn hello(&self, param: Param) -> String {
         let name = param.get("name").unwrap();
         format!("Hello, {}!", name)
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-async-std = { version = "1.6.0", features = ["attributes"] }
+async-std = { version = "1.6", features = ["attributes"] }
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -6,8 +6,8 @@ description = "Modular backend framework for web applications"
 license = "MIT"
 
 [dependencies]
-syn = "2.0.29"
-quote = "1.0.33"
+syn = "2.0"
+quote = "1.0"
 ngyn_shared = { version = "0.3.1", path = "../shared" }
 
 [lib]

--- a/crates/macros/src/core/dto_macro.rs
+++ b/crates/macros/src/core/dto_macro.rs
@@ -2,119 +2,16 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::DeriveInput;
 
-use crate::utils::parse_macro_data;
-
-struct DtoArgs {
-    validator: Option<syn::LitStr>,
-    reporter: Option<syn::LitStr>,
-}
-
-impl syn::parse::Parse for DtoArgs {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let mut validator = None;
-        let mut reporter = None;
-        while !input.is_empty() {
-            let ident = input.parse::<syn::Ident>()?;
-            match ident.to_string().as_str() {
-                "validator" => {
-                    let _: syn::Token![=] = input.parse()?;
-                    validator = Some(input.parse()?);
-                }
-                "reporter" => {
-                    let _: syn::Token![=] = input.parse()?;
-                    reporter = Some(input.parse()?);
-                }
-                _ => {
-                    return Err(syn::Error::new(
-                        ident.span(),
-                        "Unknown attribute for dto macro",
-                    ));
-                }
-            }
-        }
-        Ok(Self {
-            validator,
-            reporter,
-        })
-    }
-}
-
-pub fn dto_macro(args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn dto_macro(input: TokenStream) -> TokenStream {
     let DeriveInput {
-        ident,
-        data,
-        attrs,
-        vis,
-        generics,
+        ident, generics, ..
     } = syn::parse_macro_input!(input as DeriveInput);
-    let DtoArgs {
-        validator,
-        reporter,
-    } = syn::parse_macro_input!(args as DtoArgs);
-
-    let dto_fields = parse_macro_data(data);
-
-    let fields: Vec<_> = dto_fields
-        .iter()
-        .map(
-            |syn::Field {
-                 ident,
-                 ty,
-                 vis,
-                 attrs,
-                 colon_token,
-                 ..
-             }| {
-                quote! {
-                    #(#attrs),* #vis #ident #colon_token #ty
-                }
-            },
-        )
-        .collect();
-
-    let validation = if validator.is_some() {
-        let ident = validator.unwrap().parse::<syn::Ident>().unwrap();
-        let reporter = if reporter.is_some() {
-            let ident = reporter.unwrap().parse::<syn::Ident>().unwrap();
-            quote! {
-                res.send(#ident(err));
-            }
-        } else {
-            quote! {
-                res.send(err.to_string());
-            }
-        };
-        quote! {
-            if let Err(err) = data.#ident() {
-                res.set_status(400);
-                #reporter
-                return None;
-            }
-        }
-    } else {
-        quote! {}
-    };
 
     let expanded = quote! {
-        #(#attrs)*
-        #vis struct #ident #generics {
-            #(#fields),*
-        }
-
-        impl #generics ngyn::prelude::Transformer for #ident #generics {
-            fn transform(cx: &mut ngyn::prelude::NgynContext, res: &mut ngyn::prelude::NgynResponse) -> Option<Self> {
-                let dto = ngyn::prelude::Dto::transform(cx, res).unwrap();
-                match dto.parse::<#ident>() {
-                    Ok(data) => {
-                        #validation
-                        return Some(data);
-                    }
-                    Err(err) => {
-                        res.set_status(400);
-                        res.send(err.to_string());
-                        return None;
-                    }
-                }
+        impl #generics ngyn::prelude::Transformer<'_> for #ident #generics {
+            fn transform(cx: &mut ngyn::prelude::NgynContext, res: &mut ngyn::prelude::NgynResponse) -> Self {
+                let dto = ngyn::prelude::Dto::transform(cx, res);
+                dto.parse::<#ident>().unwrap()
             }
         }
     };

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -290,16 +290,16 @@ pub fn check(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_attribute]
+#[proc_macro_derive(Dto)]
 /// The `Dto` derive macro is used to generate a DTO struct.
 ///
 /// ##### Example
 /// ```rust ignore
-/// #[dto]
+/// #[derive(Dto)]
 /// struct MyDto {
 ///     // fields
 /// }
 /// ```
-pub fn dto(args: TokenStream, input: TokenStream) -> TokenStream {
-    dto_macro(args, input)
+pub fn dto(input: TokenStream) -> TokenStream {
+    dto_macro(input)
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.74"
+async-trait = "0.1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
-regex = "1.10.4"
+regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "2.5.0"

--- a/crates/shared/src/server/context.rs
+++ b/crates/shared/src/server/context.rs
@@ -316,8 +316,14 @@ impl NgynContext {
     }
 }
 
-impl Transformer for NgynRequest {
-    fn transform(cx: &mut NgynContext, _res: &mut NgynResponse) -> Option<Self> {
-        Some(cx.request.clone())
+impl<'a> Transformer<'a> for &'a NgynContext {
+    fn transform(cx: &'a mut NgynContext, _res: &'a mut NgynResponse) -> Self {
+        cx
+    }
+}
+
+impl<'a> Transformer<'a> for &'a NgynRequest {
+    fn transform(cx: &'a mut NgynContext, _res: &'a mut NgynResponse) -> Self {
+        &(cx.request)
     }
 }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use http_body_util::Full;
 use hyper::{body::Bytes, Method, Request, Response, StatusCode};
 
-use crate::{context::NgynContext, Handler, NgynResponse, ToBytes};
+use crate::{context::NgynContext, Handler, NgynResponse, ToBytes, Transformer};
 
 /// Trait representing a full response.
 pub trait FullResponse {
@@ -61,6 +61,12 @@ impl FullResponse for NgynResponse {
 
     fn send(&mut self, item: impl ToBytes) {
         *self.body_mut() = Full::new(item.to_bytes());
+    }
+}
+
+impl<'a> Transformer<'a> for &'a NgynResponse {
+    fn transform(_cx: &'a mut NgynContext, res: &'a mut NgynResponse) -> Self {
+        res
     }
 }
 

--- a/crates/vercel/Cargo.toml
+++ b/crates/vercel/Cargo.toml
@@ -11,4 +11,4 @@ hyper = { version = "1", features = ["full"] }
 ngyn_macros = { version = "0.3.1", path = "../macros" }
 ngyn_shared = { version = "0.3.1", path = "../shared" }
 tokio = { version = "1", features = ["full"] }
-vercel_runtime = { version = "1.1.0" }
+vercel_runtime = { version = "1.1" }

--- a/examples/weather_app/src/modules/weather/weather_controller.rs
+++ b/examples/weather_app/src/modules/weather/weather_controller.rs
@@ -6,8 +6,7 @@ use super::weather_gate::WeatherGate;
 use super::weather_service::WeatherService;
 use crate::middlewares::test_middleware::TestMiddleware;
 
-#[dto(validator = "validate")]
-#[derive(Validate, Serialize, Deserialize)]
+#[derive(Dto, Validate, Serialize, Deserialize)]
 pub struct WeatherDto {
     pub location: String,
     pub temperature: f32,

--- a/examples/weather_app/src/modules/weather/weather_gate.rs
+++ b/examples/weather_app/src/modules/weather/weather_gate.rs
@@ -5,7 +5,7 @@ pub struct WeatherGate;
 
 impl NgynGate for WeatherGate {
     fn can_activate(self, cx: &mut NgynContext, res: &mut NgynResponse) -> bool {
-        let query = Query::transform(cx, res).unwrap();
+        let query = Query::transform(cx, res);
         if query.get("location").is_some() {
             return true;
         }


### PR DESCRIPTION
In #94, a couple of changes got added which breaks ngyn really bad. They were added in an attempt to add in-built support for validation but that seems unnecessary.

This PR corrects this change. It not only does this but aslo adds support for transforming references of `context`, `request` and `response`. This would make it easier to build pluggable modules in ngyn v0.4.

The last change this PR brings is a reverse of dto back to the initial design of derive macros which are better in terms of ergonomics