### PR TITLE
feat: use state support in platforms

### DIFF
--- a/crates/shared/src/core/engine.rs
+++ b/crates/shared/src/core/engine.rs
@@ -31,9 +31,19 @@ impl PlatformData {
     ///
     /// The response to the request.
     pub async fn respond(&self, req: Request<Vec<u8>>) -> NgynResponse {
-        let state = self.state.as_ref().unwrap().clone();
-        NgynResponse::build_with_state(req, self.routes.clone(), self.middlewares.clone(), state)
-            .await
+        match self.state {
+            Some(ref state) => {
+                let state = state.clone();
+                NgynResponse::build_with_state(
+                    req,
+                    self.routes.clone(),
+                    self.middlewares.clone(),
+                    state,
+                )
+                .await
+            }
+            None => NgynResponse::build(req, self.routes.clone(), self.middlewares.clone()).await,
+        }
     }
 
     /// Adds a route to the platform data.
@@ -125,7 +135,7 @@ pub trait NgynEngine: NgynPlatform {
         self.data_mut().add_middleware(Box::new(middleware));
     }
 
-    fn use_state(&mut self, state: impl AppState) {
+    fn set_state(&mut self, state: impl AppState) {
         self.data_mut().state = Some(Arc::new(state));
     }
 

--- a/crates/shared/src/server/context.rs
+++ b/crates/shared/src/server/context.rs
@@ -23,7 +23,7 @@ impl<V> NgynContextValue<V> {
 }
 
 /// Represents the state of an application in Ngyn
-pub trait AppState: Any + Send {
+pub trait AppState: Any + Send + Sync {
     fn as_any(&self) -> &dyn Any
     where
         Self: Sized,
@@ -33,7 +33,7 @@ pub trait AppState: Any + Send {
     fn get_state(&self) -> &dyn Any;
 }
 
-impl<T: Send + Sized + 'static> AppState for T {
+impl<T: Send + Sync + 'static> AppState for T {
     fn get_state(&self) -> &dyn Any {
         self
     }

--- a/crates/shared/src/server/response.rs
+++ b/crates/shared/src/server/response.rs
@@ -133,11 +133,11 @@ pub(crate) trait ResponseBuilder: FullResponse {
         middlewares: Arc<Mutex<Middlewares>>,
     ) -> Self;
 
-    async fn build_with_state<T: AppState>(
+    async fn build_with_state(
         req: Request<Vec<u8>>,
         routes: Arc<Mutex<Routes>>,
         middlewares: Arc<Mutex<Middlewares>>,
-        state: T,
+        state: impl AppState,
     ) -> Self;
 }
 
@@ -151,11 +151,11 @@ impl ResponseBuilder for NgynResponse {
         Self::build_with_state(req, routes, middlewares, ()).await
     }
 
-    async fn build_with_state<T: AppState>(
+    async fn build_with_state(
         req: Request<Vec<u8>>,
         routes: Arc<Mutex<Vec<(String, Method, Box<Handler>)>>>,
         middlewares: Arc<Mutex<Vec<Box<dyn crate::traits::NgynMiddleware>>>>,
-        state: T,
+        state: impl AppState,
     ) -> Self {
         let mut cx = NgynContext::from_request(req);
         let mut res = Response::new(Full::new(Bytes::default()));


### PR DESCRIPTION
This PR would allow passing state directly from platforms to context and introduce a method which can be sued as below:

```rust
let mut app = Platform::default(); // any valid platform

app.set_state(MyAppState {});

```