### PR TITLE
feat(core): `fn` type routes

### DIFF
--- a/crates/macros/src/common/route.rs
+++ b/crates/macros/src/common/route.rs
@@ -1,13 +1,134 @@
 use proc_macro::TokenStream;
-use syn::ItemFn;
+use quote::quote;
+use syn::{ItemFn, Signature};
 
-pub(crate) fn route_macro(_args: TokenStream, raw_input: TokenStream) -> TokenStream {
-    match syn::parse::<ItemFn>(raw_input.clone()) {
-        Ok(input) => input,
-        Err(err) => {
-            panic!("failed to parse route: {}", err)
+use super::routes::RouteArgs;
+
+pub(crate) fn route_macro(args: TokenStream, raw_input: TokenStream) -> TokenStream {
+    let input = raw_input.clone();
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    } = syn::parse_macro_input!(input as ItemFn);
+
+    let Signature {
+        ident,
+        inputs,
+        output,
+        generics,
+        constness,
+        asyncness,
+        unsafety,
+        ..
+    } = sig;
+
+    if let Some(syn::FnArg::Receiver(_)) = inputs.first() {
+        // Skip transforming methods, only transform functions
+        // We handle methods in the `routes` macro
+        raw_input
+    } else {
+        let RouteArgs { http_method, path } = syn::parse_macro_input!(args as RouteArgs);
+
+        let mut routes = Vec::new();
+        if let Some(path) = path {
+            path.each(|path| {
+                routes.push(quote! {(
+                    #http_method.to_string(),
+                    #path.to_string(),
+                    stringify!(#ident).to_string(),
+                )});
+            });
         }
-    };
 
-    raw_input
+        let args = inputs.iter().fold(None, |args, input| {
+            if let syn::FnArg::Typed(pat) = input {
+                let ty = &pat.ty;
+                let (path, and_token, mutability) = {
+                    if let syn::Type::Reference(path_ref) = *ty.clone() {
+                        if let syn::Type::Path(path) = *path_ref.elem.clone() {
+                            (
+                                path.path,
+                                Some(path_ref.and_token),
+                                path_ref.mutability,
+                            )
+                        } else {
+                            panic!("Expected a reference or a path");
+                        }
+                    } else if let syn::Type::Path(path) = *ty.clone() {
+                        (path.path, None, None)
+                    } else {
+                        panic!("Expected a reference or a path");
+                    }
+                };
+                let arg_def = quote! {
+                    #and_token #mutability ngyn::prelude::Transducer::reduce::<#and_token #mutability #path>(cx, res)
+                };
+                if args.is_none() {
+                    Some(quote! {
+                        #arg_def
+                    })
+                } else {
+                    Some(quote! {
+                        #args, #arg_def
+                    })
+                }
+            } else {
+                args
+            }
+        });
+        let handle_body = if asyncness.is_some() {
+            match output {
+                syn::ReturnType::Type(_, _) => quote! {
+                    let body = self.#ident(#args).await;
+                    res.send(body);
+                },
+                _ => quote! {
+                    self.#ident(#args).await;
+                },
+            }
+        } else {
+            match output {
+                syn::ReturnType::Type(_, _) => quote! {
+                    let body = self.#ident(#args);
+                    res.send(body);
+                },
+                _ => quote! {
+                    self.#ident(#args);
+                },
+            }
+        };
+
+        let expanded = quote::quote! {
+            #(#attrs)*
+            #vis #constness #asyncness #unsafety fn #ident #generics(#inputs) #output #block
+
+            impl #generics ngyn::shared::traits::NgynInjectable for #ident {
+                fn new() -> Self {
+                    Self
+                }
+            }
+
+            #[ngyn::prelude::async_trait]
+            impl #generics ngyn::shared::traits::NgynController for #ident {
+                fn routes(&self) -> Vec<(String, String, String)> {
+                    vec![#(#routes),*]
+                }
+
+                async fn handle(
+                    &mut self,
+                    handler: &str,
+                    cx: &mut ngyn::prelude::NgynContext,
+                    res: &mut ngyn::prelude::NgynResponse,
+                ) {
+                    self.inject(cx);
+                    if handler == stringify!(#ident) {
+                        #handle_body;
+                    }
+                }
+            }
+        };
+        expanded.into()
+    }
 }

--- a/examples/weather_app/src/main.rs
+++ b/examples/weather_app/src/main.rs
@@ -2,12 +2,19 @@ mod middlewares;
 mod modules;
 mod shared;
 
+use std::sync::Arc;
+
 use dotenv::dotenv;
 use modules::AppModule;
 use ngyn::prelude::*;
 use ngyn_shuttle::{ShuttleApplication, ShuttleNgyn};
 
 use crate::middlewares::notfound_middleware::NotFoundMiddleware;
+
+#[route("GET", "/")]
+pub async fn fn_route() -> String {
+    "Hello, World!".to_string()
+}
 
 #[shuttle_runtime::main]
 async fn main() -> ShuttleNgyn {
@@ -16,6 +23,7 @@ async fn main() -> ShuttleNgyn {
 
     app.use_middleware(NotFoundMiddleware::new());
     app.use_interpreter(shared::ResponseInterpreter {});
+    app.load_controller(Arc::new(Box::new(fn_route.into())));
 
     Ok(app.into())
 }


### PR DESCRIPTION
This is heavily in WIP.

The idea behind this PR is to introduce into ngyn support for function type/free/uncontrolled routes.

Function type routes would essentially be created from functions decorated with a route macro or it's derivatives. Something like this below

```rust
#[get("/")]
fn get_home() -> &str {
   "Hello from a function"
}
```