### PR TITLE
chore(core): default platform engine to `hyper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "http 1.1.0",
+ "ngyn-hyper 0.1.0",
  "ngyn_macros 0.4.3",
  "ngyn_shared 0.4.3",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,3 +15,4 @@ async-trait = "0.1"
 http = "1"
 ngyn_macros = { version = "0.4", path = "../macros" }
 ngyn_shared = { version = "0.4", path = "../shared" }
+ngyn-hyper = { version = "0.1", path = "../hyper" }

--- a/crates/core/src/factory.rs
+++ b/crates/core/src/factory.rs
@@ -1,7 +1,8 @@
+use ngyn_hyper::HyperApplication;
 use ngyn_shared::{core::NgynEngine, traits::NgynModule};
 
 /// The `NgynFactory` struct is used to create instances of `NgynEngine`.
-pub struct NgynFactory<Application: NgynEngine> {
+pub struct NgynFactory<Application: NgynEngine = HyperApplication> {
     /// this is just a placeholder and would prolly not be used
     _app: Application,
 }
@@ -14,12 +15,11 @@ impl<Application: NgynEngine> NgynFactory<Application> {
     ///
     /// ```rust ignore
     /// use ngyn::prelude::*;
-    /// use ngyn_hyper::HyperApplication;
     ///
     /// #[module]
     /// pub struct YourAppModule;
     ///
-    /// let server = NgynFactory::<HyperApplication>::create::<YourAppModule>();
+    /// let server: HyperApplication = NgynFactory::create::<YourAppModule>();
     /// ```
     pub fn create<AppModule: NgynModule + 'static>() -> Application {
         Application::build::<AppModule>()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-pub mod app;
+pub mod factory;
 
 pub mod macros {
     pub use async_std::main;
@@ -13,7 +13,7 @@ pub mod shared {
 
 #[doc(hidden)]
 pub mod prelude {
-    pub use crate::app::*;
+    pub use crate::factory::*;
     pub use crate::macros::*;
     pub use ngyn_shared::{
         core::NgynEngine,

--- a/examples/vercel_app/api/[[...all]].rs
+++ b/examples/vercel_app/api/[[...all]].rs
@@ -1,4 +1,4 @@
-use ngyn::app::NgynFactory;
+use ngyn::factory::NgynFactory;
 use ngyn_swagger::NgynEngineSwagger;
 use ngyn_vercel::VercelApplication;
 use vercel_app::modules::sample::sample_module::SampleModule;


### PR DESCRIPTION
This used to be part of ngyn when tide was still supported. However, for some reason during iterations and improvement in factory specifications, it was removed.

The idea is to not require an explicit platform engine. If a platform engine isn't specified, then we make use of hyper