### PR TITLE
fix: manually drop app state to prevent poisoning

### DIFF
--- a/crates/macros/CHANGELOG.md
+++ b/crates/macros/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. See [conven
 
 ## Unreleased
 #### Bug Fixes
+- [#243](../../../../pull/243) **routing**: `#[handler]` macro compile time + arguments reduction fixes
 
 #### Features
 

--- a/crates/macros/src/common/handler.rs
+++ b/crates/macros/src/common/handler.rs
@@ -74,28 +74,21 @@ pub fn handler_macro(args: TokenStream, raw_input: TokenStream) -> TokenStream {
     let mut generics_stream = generics.to_token_stream();
     generics_stream.extend(quote! { '_cx_lifetime });
 
-    let args = inputs.iter().filter_map(|input| {
-        if let syn::FnArg::Typed(pat) = input {
-            let (path, and_token, mutability) = match pat.ty.as_ref() {
-                syn::Type::Reference(path_ref) => match path_ref.elem.as_ref() {
-                    syn::Type::Path(path) => (&path.path, Some(path_ref.and_token), path_ref.mutability),
-                    _ => panic!("Expected a reference or a path"),
-                },
-                syn::Type::Path(path) => (&path.path, None, None),
-                _ => panic!("Expected a reference or a path"),
-            };
-            Some(quote! {
-                #and_token #mutability ngyn::prelude::Transducer::reduce::<#and_token #mutability #path>(cx)
-            })
-        } else {
-            None
-        }
-    }).reduce(|acc, arg| quote! { #acc, #arg });
+    let args = inputs
+        .iter()
+        .map(|input| {
+            if let syn::FnArg::Typed(_) = input {
+                quote! { ngyn::prelude::Transducer::reduce(cx) }
+            } else {
+                panic!("Only associated functions are supported");
+            }
+        })
+        .reduce(|args, arg| quote! { #args, #arg });
 
     let gate_handlers = gates.iter().map(|path| {
         quote! {
             if !#path::can_activate(cx).await {
-                return;
+                return Box::new(()) as Box<dyn ngyn::prelude::ToBytes>;
             }
         }
     });
@@ -107,37 +100,29 @@ pub fn handler_macro(args: TokenStream, raw_input: TokenStream) -> TokenStream {
     });
 
     let exe_block = quote! {
-        use ngyn::prelude::{NgynMiddleware, NgynGate};
+        use ngyn::prelude::{NgynMiddleware, NgynGate, ToBytes};
         #(#middlewares_stream)*
         #(#gate_handlers)*
     };
 
-    let body = match (asyncness.is_some(), &output) {
-        (true, syn::ReturnType::Type(_, ty)) => quote! {
-            let fn_body = (|#inputs| #asyncness move #block);
+    let body = match asyncness.is_some() {
+        true => quote! {
+            async fn handle(#inputs) #output #block
+            let body = handle(#args);
             Box::pin(#asyncness move {
                 #exe_block;
-                let output: #ty = fn_body(#args).await;
-                *cx.response_mut().body_mut() = output.to_bytes().into();
+                Box::new(body.await) as Box<dyn ngyn::prelude::ToBytes>
             })
         },
-        (true, syn::ReturnType::Default) => quote! {
-            let fn_body = (|#inputs| #asyncness move #block);
-            Box::pin(#asyncness move {
-                #exe_block;
-                fn_body(#args).await;
-            })
-        },
-        (false, syn::ReturnType::Default) => quote! { (|#inputs| #block)(#args); },
-        (false, syn::ReturnType::Type(_, ty)) => quote! {
-            let output: #ty = (|#inputs| #block)(#args);
+        false => quote! {
+            let output = (|#inputs| #block)(#args);
             *cx.response_mut().body_mut() = output.to_bytes().into();
         },
     };
 
     let output = asyncness.map(|_| {
         let r_arrow = RArrow::default();
-        quote! { #r_arrow std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_cx_lifetime>> }
+        quote! { #r_arrow std::pin::Pin<Box<dyn std::future::Future<Output = Box<dyn ngyn::prelude::ToBytes>> + Send + '_cx_lifetime>> }
     });
 
     quote! {

--- a/crates/macros/src/common/state.rs
+++ b/crates/macros/src/common/state.rs
@@ -15,6 +15,17 @@ pub(crate) fn derive_app_state_macro(input: TokenStream) -> TokenStream {
                 self
             }
         }
+
+        impl<'a> #impl_generics ngyn::shared::server::Transformer<'a> for &'a #ident #ty_generics #where_clause {
+            fn transform(cx: &'a mut ngyn::prelude::NgynContext<'_>) -> Self {
+                cx.state::<#ident>().unwrap()
+            }
+        }
+        impl<'a> #impl_generics ngyn::shared::server::Transformer<'a> for &'a mut #ident #ty_generics #where_clause {
+            fn transform(cx: &'a mut ngyn::prelude::NgynContext<'_>) -> Self {
+                cx.state_mut::<#ident>().unwrap()
+            }
+        }
     };
     TokenStream::from(expanded)
 }

--- a/crates/macros/src/core/dto.rs
+++ b/crates/macros/src/core/dto.rs
@@ -15,7 +15,7 @@ pub(crate) fn dto_macro(input: TokenStream) -> TokenStream {
         }
 
         impl #impl_generics ngyn::shared::server::ToBytes for #ident #ty_generics #where_clause {
-            fn to_bytes(self) -> ngyn::shared::server::Bytes {
+            fn to_bytes(&self) -> ngyn::shared::server::Bytes {
                 ngyn::shared::server::Bytes::from(serde_json::to_string(&self).unwrap())
             }
         }

--- a/crates/macros/tests/common/state.expanded.rs
+++ b/crates/macros/tests/common/state.expanded.rs
@@ -12,3 +12,13 @@ impl ngyn::shared::server::context::AppState for TestState {
         self
     }
 }
+impl<'a> ngyn::shared::server::Transformer<'a> for &'a TestState {
+    fn transform(cx: &'a mut ngyn::prelude::NgynContext<'_>) -> Self {
+        cx.state::<TestState>().unwrap()
+    }
+}
+impl<'a> ngyn::shared::server::Transformer<'a> for &'a mut TestState {
+    fn transform(cx: &'a mut ngyn::prelude::NgynContext<'_>) -> Self {
+        cx.state_mut::<TestState>().unwrap()
+    }
+}

--- a/crates/macros/tests/core/dto.expanded.rs
+++ b/crates/macros/tests/core/dto.expanded.rs
@@ -11,7 +11,7 @@ impl ngyn::shared::server::Transformer<'_> for User {
     }
 }
 impl ngyn::shared::server::ToBytes for User {
-    fn to_bytes(self) -> ngyn::shared::server::Bytes {
+    fn to_bytes(&self) -> ngyn::shared::server::Bytes {
         ngyn::shared::server::Bytes::from(serde_json::to_string(&self).unwrap())
     }
 }

--- a/crates/shared/CHANGELOG.md
+++ b/crates/shared/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. See [conven
 
 ## Unreleased
 #### Bug Fixes
+- [#243](../../../../pull/243) **routing**: manually drop app state to prevent poisoning
 
 #### Features
 

--- a/crates/shared/src/core/handler.rs
+++ b/crates/shared/src/core/handler.rs
@@ -5,9 +5,11 @@ use http::{HeaderValue, StatusCode};
 use crate::server::{NgynContext, ToBytes};
 
 /// Represents a handler function that takes in a mutable reference to `NgynContext` and `NgynResponse`.
-pub(crate) type Handler = dyn Fn(&mut NgynContext) + Send + Sync + 'static;
+pub(crate) type Handler = dyn Fn(&mut NgynContext) -> Box<dyn ToBytes> + Send + Sync + 'static;
 
-pub(crate) type AsyncHandler = dyn for<'a, 'b> Fn(&'a mut NgynContext) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>
+pub type AsyncHandler = dyn for<'a, 'b> Fn(
+        &'a mut NgynContext,
+    ) -> Pin<Box<dyn Future<Output = Box<dyn ToBytes>> + Send + 'a>>
     + Send
     + Sync;
 
@@ -16,15 +18,15 @@ pub enum RouteHandler {
     Async(Box<AsyncHandler>),
 }
 
-impl<F: Fn(&mut NgynContext) + Send + Sync + 'static> From<F> for RouteHandler {
-    fn from(f: F) -> Self {
-        RouteHandler::Sync(Box::new(f))
-    }
-}
-
 impl From<Box<AsyncHandler>> for RouteHandler {
     fn from(f: Box<AsyncHandler>) -> Self {
         RouteHandler::Async(f)
+    }
+}
+
+impl<F: Fn(&mut NgynContext) -> Box<dyn ToBytes> + Send + Sync + 'static> From<F> for RouteHandler {
+    fn from(f: F) -> Self {
+        RouteHandler::Sync(Box::new(f))
     }
 }
 
@@ -44,8 +46,8 @@ pub fn handler<S: ToBytes + 'static>(
     f: impl Fn(&mut NgynContext) -> S + Send + Sync + 'static,
 ) -> Box<Handler> {
     Box::new(move |ctx: &mut NgynContext| {
-        let body = f(ctx).to_bytes();
-        *ctx.response_mut().body_mut() = body.into();
+        let body = f(ctx);
+        Box::new(body) as Box<dyn ToBytes>
     })
 }
 
@@ -67,12 +69,15 @@ pub fn async_handler<S: ToBytes + 'static, Fut: Future<Output = S> + Send + 'sta
         Box::pin(async move {
             let body = fut.await.to_bytes();
             *ctx.response_mut().body_mut() = body.into();
+            Box::new(()) as Box<dyn ToBytes>
         })
     })
 }
 
 pub fn async_wrap(
-    f: impl for<'a, 'b> Fn(&'a mut NgynContext) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>
+    f: impl for<'a, 'b> Fn(
+            &'a mut NgynContext,
+        ) -> Pin<Box<dyn Future<Output = Box<dyn ToBytes>> + Send + 'a>>
         + Send
         + Sync
         + 'static,
@@ -86,6 +91,7 @@ pub fn async_wrap(
 pub fn not_implemented() -> Box<Handler> {
     Box::new(|ctx: &mut NgynContext| {
         *ctx.response_mut().status_mut() = StatusCode::NOT_IMPLEMENTED;
+        Box::new(()) as Box<dyn ToBytes>
     })
 }
 
@@ -96,6 +102,7 @@ pub fn redirect_to(location: &'static str) -> Box<Handler> {
             .headers_mut()
             .insert("Location", HeaderValue::from_str(location).unwrap());
         *ctx.response_mut().status_mut() = StatusCode::SEE_OTHER;
+        Box::new(()) as Box<dyn ToBytes>
     })
 }
 
@@ -106,6 +113,7 @@ pub fn redirect_temporary(location: &'static str) -> Box<Handler> {
             .headers_mut()
             .insert("Location", HeaderValue::from_str(location).unwrap());
         *ctx.response_mut().status_mut() = StatusCode::TEMPORARY_REDIRECT;
+        Box::new(()) as Box<dyn ToBytes>
     })
 }
 
@@ -116,6 +124,7 @@ pub fn redirect_permanent(location: &'static str) -> Box<Handler> {
             .headers_mut()
             .insert("Location", HeaderValue::from_str(location).unwrap());
         *ctx.response_mut().status_mut() = StatusCode::MOVED_PERMANENTLY;
+        Box::new(()) as Box<dyn ToBytes>
     })
 }
 
@@ -126,5 +135,6 @@ pub fn redirect_found(location: &'static str) -> Box<Handler> {
             .headers_mut()
             .insert("Location", HeaderValue::from_str(location).unwrap());
         *ctx.response_mut().status_mut() = StatusCode::FOUND;
+        Box::new(()) as Box<dyn ToBytes>
     })
 }

--- a/crates/shared/src/server/body.rs
+++ b/crates/shared/src/server/body.rs
@@ -25,126 +25,132 @@ pub trait ToBytes {
     /// let bytes: Bytes = Bytes::from("Hello, world!");
     /// let parsed_bytes: Bytes = bytes.to_bytes();
     /// ```
-    fn to_bytes(self) -> Bytes;
+    fn to_bytes(&self) -> Bytes;
 }
 
 impl ToBytes for () {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::default()
     }
 }
 
+impl ToBytes for Box<dyn ToBytes> {
+    fn to_bytes(&self) -> Bytes {
+        self.as_ref().to_bytes()
+    }
+}
+
 impl ToBytes for &'static str {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.as_bytes())
     }
 }
 
 impl ToBytes for String {
-    fn to_bytes(self) -> Bytes {
-        Bytes::from(self)
+    fn to_bytes(&self) -> Bytes {
+        Bytes::from(self.to_owned())
     }
 }
 
 impl ToBytes for Bytes {
-    fn to_bytes(self) -> Bytes {
-        self
+    fn to_bytes(&self) -> Bytes {
+        self.clone()
     }
 }
 
 impl ToBytes for i8 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for i16 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for i32 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for i64 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for i128 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for f32 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for f64 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for u8 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for u16 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for u32 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for u64 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for u128 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for bool {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
 impl ToBytes for Value {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         Bytes::from(self.to_string())
     }
 }
 
-impl<T: Serialize> ToBytes for Vec<T> {
-    fn to_bytes(self) -> Bytes {
+impl<T: Serialize + 'static> ToBytes for Vec<T> {
+    fn to_bytes(&self) -> Bytes {
         let json = json!(self);
         json.to_bytes()
     }
 }
 
-impl<D: Serialize, E: Serialize> ToBytes for JsonResponse<D, E> {
-    fn to_bytes(self) -> Bytes {
+impl<D: Serialize + 'static, E: Serialize + 'static> ToBytes for JsonResponse<D, E> {
+    fn to_bytes(&self) -> Bytes {
         if let Some(data) = self.data() {
             return json!({ "data": data }).to_bytes();
         }
@@ -160,7 +166,7 @@ where
     T: ToBytes + Serialize + Any,
     E: ToBytes + Serialize + Any,
 {
-    fn to_bytes(self) -> Bytes {
+    fn to_bytes(&self) -> Bytes {
         if TypeId::of::<E>() == TypeId::of::<Value>() && TypeId::of::<T>() == TypeId::of::<Value>()
         {
             // This is likely a JsonResult


### PR DESCRIPTION
Noticed something really weird about context state's over the last week. The state gets poisoned randomly.

The main essence of this PR is to address this. However, this PR also improves a couyple other things:
- Handler macro should be faster and with less boilerplate
- `ToBytes` no longer takes data ownership (this is needed for transition to v0.6)

Generally, asides the slight wonership change to `ToBytes`, there are no other changes to the API